### PR TITLE
Close server when rtm.stopServer() is invoked

### DIFF
--- a/src/mocker/rtm.js
+++ b/src/mocker/rtm.js
@@ -85,6 +85,7 @@ rtm.stopServer = function (token) {
   return new Promise((resolve, reject) => {
     const wss = wssServers.get(token)
     if (!wss) {
+      server.close()
       return resolve()
     }
 
@@ -96,6 +97,7 @@ rtm.stopServer = function (token) {
 
       logger.debug(`server ${token} closed`)
       wssServers.delete(token)
+      server.close()
       resolve()
     })
   })

--- a/src/mocker/rtm.js
+++ b/src/mocker/rtm.js
@@ -85,8 +85,7 @@ rtm.stopServer = function (token) {
   return new Promise((resolve, reject) => {
     const wss = wssServers.get(token)
     if (!wss) {
-      server.close()
-      return resolve()
+      return server.close(() => resolve())
     }
 
     wss.close((err) => {
@@ -97,8 +96,7 @@ rtm.stopServer = function (token) {
 
       logger.debug(`server ${token} closed`)
       wssServers.delete(token)
-      server.close()
-      resolve()
+      return server.close(() => resolve())
     })
   })
 }

--- a/test/mocker/rtm.spec.js
+++ b/test/mocker/rtm.spec.js
@@ -33,10 +33,13 @@ describe('mocker: rtm', function () {
       Server: sinon.stub()
     }
 
-    serverMock = 'server'
+    serverMock = {
+      close: sinon.stub().returns()
+    }
 
     expressAppMock = {
-      listen: sinon.stub().returns(serverMock)
+      listen: sinon.stub().returns(serverMock),
+      close: serverMock.close()
     }
 
     expressMock = sinon.stub().returns(expressAppMock)

--- a/test/mocker/rtm.spec.js
+++ b/test/mocker/rtm.spec.js
@@ -34,12 +34,11 @@ describe('mocker: rtm', function () {
     }
 
     serverMock = {
-      close: sinon.stub().returns()
+      close: sinon.stub().yields()
     }
 
     expressAppMock = {
-      listen: sinon.stub().returns(serverMock),
-      close: serverMock.close()
+      listen: sinon.stub().returns(serverMock)
     }
 
     expressMock = sinon.stub().returns(expressAppMock)

--- a/test/mocker/rtm.spec.js
+++ b/test/mocker/rtm.spec.js
@@ -256,6 +256,7 @@ describe('mocker: rtm', function () {
       return rtm.stopServer(token)
         .then(() => {
           expect(wsServerMock.close).to.have.been.called
+          expect(serverMock.close).to.have.been.called
         })
     })
 
@@ -274,6 +275,7 @@ describe('mocker: rtm', function () {
       return rtm.stopServer('notreal')
         .then(() => {
           expect(wsServerMock.close).not.to.have.been.called
+          expect(serverMock.close).to.have.been.called
         })
     })
 


### PR DESCRIPTION
Fixes issue #25.
I’m not sure this is the most appropriate way to fix the issue, but it does the job!